### PR TITLE
New Basin Term Web Service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,9 @@ repositories {
 
 dependencies {
   providedCompile 'org.apache.tomcat:tomcat-catalina:8.0.45'
-  compile 'com.google.guava:guava:24.1-jre'
+  compile project(':nshmp-haz')
+}
+
+war {
+  webAppDirName = 'webapp'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'nshmp-site'
+include 'nshmp-haz'
+project(':nshmp-haz').projectDir = new File(settingsDir, '../nshmp-haz')

--- a/src/gov/usgs/earthquake/nshmp/site/www/ArcGis.java
+++ b/src/gov/usgs/earthquake/nshmp/site/www/ArcGis.java
@@ -1,0 +1,78 @@
+package gov.usgs.earthquake.nshmp.site.www;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Map;
+
+import static gov.usgs.earthquake.nshmp.site.www.Util.GSON;
+
+/**
+ * Class to handle all calls to the ArcGis Online service:
+ *  https://dev-earthquake.cr.usgs.gov/arcgis/rest/services/haz/basin/MapServer/identify
+ *   
+ * @author Brandon Clayton
+ */
+public class ArcGis {
+  private static final String SERVICE_URL = "https://dev-earthquake.cr.usgs.gov/" +
+      "arcgis/rest/services/haz/basin/MapServer/identify?"; 
+  
+  /**
+   * Call the identify ArcGis Online web service for a single point location
+   *    and return a {@code ArcGisResult}.
+   * <br>
+   * Deserialization of the ArcGis JSON response is conducted throw,
+   *    {@link Util.ArcGisDeserializer}.
+   *    
+   * @param latitude - The latitude in degrees of a location.
+   * @param longitude - The longitude in degrees of a location.
+   * @return The {@code ArcGisResult} with basin terms.
+   * @throws IOException
+   */
+  static ArcGisResult callService(double latitude, double longitude) 
+      throws IOException {
+    String urlStr = SERVICE_URL + 
+        "geometry=" + longitude + "," + latitude + 
+        "&tolerance=1&mapExtent=1&imageDisplay=1&f=json";
+    
+    URL url = new URL(urlStr);
+    InputStreamReader reader = new InputStreamReader(url.openStream());
+    final ArcGisReturn svcReturn = GSON.fromJson(reader, ArcGisReturn.class);
+    ArcGisResult svcResult = null;
+    try {
+      svcResult = svcReturn.results.get(0);
+    } catch (Exception e) {
+      throw new IllegalStateException("No result from: " + urlStr);
+    }
+    return svcResult;
+  }
+  
+  /**
+   * Container class to hold the JSON results from the ArcGis web service.
+   * <br>
+   * The container class is used in the {@link Util.ArcGisDeserializer}. 
+   */
+  static class ArcGisReturn {
+    ArrayList<ArcGisResult> results;
+  }
+ 
+  /**
+   * Container class for a single result from the ArcGis web service. 
+   * <br>
+   * The container class is used in the {@link Util.ArcGisDeserializer}. 
+   */
+  static class ArcGisResult {
+    double vs30;
+    Map<String, Double> basinModels;
+    
+    void setVs30(double vs30) {
+      this.vs30 = vs30;
+    }
+    
+    void setBasinModels(Map<String, Double> basinModels) {
+      this.basinModels = basinModels;
+    }
+  }
+  
+}

--- a/src/gov/usgs/earthquake/nshmp/site/www/BasinModel.java
+++ b/src/gov/usgs/earthquake/nshmp/site/www/BasinModel.java
@@ -1,0 +1,46 @@
+package gov.usgs.earthquake.nshmp.site.www;
+
+/**
+ * Basin models
+ * 
+ * @author Brandon Clayton
+ */
+public enum BasinModel {
+  
+  BAY_AREA("bayarea"),
+  CCA06("cca06"),
+  CVMH1510("cvmh1510"),
+  CVMS4("cvms4"),
+  CVMS426("cvms426"),
+  CVMS426M01("cvms426m01"),
+  LINTHURBER("linthurber"),
+  SCHMANDT_LIN("SchmandtLin"),
+  SEATTLE("Seattle"),
+  SCHEN_RITZWOLLER("SchenRitzwoller"),
+  WASATCH("Wasatch");
+  
+  public String id;
+  public String z1p0;
+  public String z2p5;
+  
+  private BasinModel(String id) {
+    this.id = id;
+    this.z1p0 = "Z1p0" + id;
+    this.z2p5 = "Z2p5" + id;
+  }
+  
+  /**
+   * Given a basin model id, find and return the corresponding
+   *    {@code BasinModels}
+   *    
+   * @param modelId - The basin model id.
+   * @return The {@code BasinModels} associated with model id.
+   */
+  static BasinModel fromId(String modelId) {
+    for (BasinModel basin : values()) {
+      if (basin.id.equals(modelId)) return basin; 
+    }
+    throw new IllegalStateException("Basin model does not exist: " + modelId);
+  }
+  
+}

--- a/src/gov/usgs/earthquake/nshmp/site/www/BasinRegion.java
+++ b/src/gov/usgs/earthquake/nshmp/site/www/BasinRegion.java
@@ -1,0 +1,181 @@
+package gov.usgs.earthquake.nshmp.site.www;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import gov.usgs.earthquake.nshmp.geo.Location;
+import gov.usgs.earthquake.nshmp.geo.LocationList;
+import gov.usgs.earthquake.nshmp.geo.Region;
+import gov.usgs.earthquake.nshmp.geo.Regions;
+import gov.usgs.earthquake.nshmp.internal.GeoJson;
+import gov.usgs.earthquake.nshmp.internal.GeoJson.Feature;
+import gov.usgs.earthquake.nshmp.internal.GeoJson.FeatureCollection;
+
+import com.google.common.base.Optional;
+
+/**
+ * Regions of interest to obtain basin terms.
+ * 
+ * Region Bounds per Allison:
+ *  <ul>
+ *    <li> Bay Area: lat 36.42 to 39.02 N, long -123.62 to -120.6 W </li>
+ *    <li> Los Angeles: lat 32.94 to 35.16 N, long -119.8 to -116.7 W </li> 
+ *    <li> Seattle: lat 46.5 to 48.5 N, long -123.5 to -121.5 W </li> 
+ *    <li> Wasatch: lat 39.0 to 42.52 N, long -113.26 to -110.74 W  </li>
+ *  </ul>
+ *  
+ *  Default basin model per Allison:
+ *  <ul>
+ *    <li> Los Angeles: cvms S4.26m01 (Lee et al., 2014) </li>
+ *    <li> Bay Area: BayArea10 (Aagaard et al., 2010) </li>
+ *    <li> Wasatch: Wasatch08 (Magistrale et al., 2008) </li>
+ *    <li> Seattle: Seattle07 (Stephenson, 2007) </li>
+ *  </ul>
+ *  
+ * @author Brandon Clayton
+ */
+public enum BasinRegion {
+
+  BAY_AREA(
+      "Bay Area",
+      new double[] {36.42, 39.02},
+      new double[] {-123.62, -120.6},
+      BasinModel.BAY_AREA),
+  
+  LOS_ANGELES(
+      "Los Angeles",
+      new double[] {32.94, 35.16},
+      new double[] {-119.8, -116.7},
+      BasinModel.CVMS426M01),
+  
+  SEATTLE(
+      "Seattle",
+      new double[] {46.5, 48.5},
+      new double[] {-123.5, -121.5},
+      BasinModel.SEATTLE),
+ 
+  WASATCH(
+      "Wasatch",
+      new double[] {39.0, 42.52},
+      new double[] {-113.26, -110.74},
+      BasinModel.WASATCH);
+ 
+  public String label;
+  public String id;
+  public final double minlatitude;
+  public final double maxlatitude;
+  public final double minlongitude;
+  public final double maxlongitude;
+  public final BasinModel defaultModel;
+  private Region region;
+  
+  private BasinRegion(
+      String label, 
+      double[] latRange, 
+      double[] lonRange,
+      BasinModel defaultModel) {
+    this.label = label;
+    this.id = this.toUpperCamel();
+    
+    this.minlatitude = latRange[0];
+    this.maxlatitude = latRange[1];
+    this.minlongitude = lonRange[0];
+    this.maxlongitude = lonRange[1];
+    this.defaultModel = defaultModel;
+    
+    this.region = this.createRegion();
+  }
+  
+  /**
+   * Convert the {@code Enum} to a lower camel case {@code String}.
+   */
+  String toUpperCamel() {
+    return UPPER_UNDERSCORE.to(LOWER_CAMEL, name());
+  }
+  
+  /**
+   * Create a {@code Region} using {@link Regions#createRectangular}
+   *    
+   * @return The {@code Region}
+   */
+  private Region createRegion() {
+    Location minBounds = Location.create(this.minlatitude, this.minlongitude);
+    Location maxBounds = Location.create(this.maxlatitude, this.maxlongitude);
+    
+    return Regions.createRectangular(this.label, minBounds, maxBounds);
+  }
+ 
+  /**
+   * Return a {@code BasinRegion} that contains a specific latitude and 
+   *    longitude.
+   *    
+   * @param lat - The latitude in degrees.
+   * @param lon - The longitude in degrees.
+   * @return The {@code BasinRegions}.
+   */
+  static BasinRegion findRegion(double lat, double lon) {
+    for (BasinRegion basinRegion : values()) {
+      Location loc = Location.create(lat, lon);
+      Boolean isContained = basinRegion.region.contains(loc);
+      if (isContained) return basinRegion;
+    }
+    
+    return null;
+  }
+  
+  /**
+   * Create a GeoJson polygon {@code Feature} using {@link GeoJson#createPolygon}
+   * 
+   * @return The polygon {@code Feature}.
+   */
+  Feature toPolygonFeature() {
+    ArrayList<Location> locs = new ArrayList<>();
+    locs.add(Location.create(this.minlatitude, this.minlongitude));
+    locs.add(Location.create(this.minlatitude, this.maxlongitude));
+    locs.add(Location.create(this.maxlatitude, this.maxlongitude));
+    locs.add(Location.create(this.maxlatitude, this.minlongitude));
+    locs.add(Location.create(this.minlatitude, this.minlongitude));
+    
+    LocationList locationList = LocationList.create(locs);
+    Feature feature = GeoJson.createPolygon(
+        this.label, 
+        locationList, 
+        Optional.of(this.id), 
+        Optional.absent());
+    
+    return feature;
+  }
+  
+  /**
+   * Create a {@code FeatureCollection} of all {@code BasinRegion}.
+   * 
+   * @return The {@code FeatureCollection}.
+   */
+  static FeatureCollection<Feature> toFeatureCollection() {
+    List<Feature> features = new ArrayList<>();
+    
+    FeatureCollection<Feature> fc = new FeatureCollection<>();
+    for (BasinRegion basinRegion : values()) {
+      features.add(basinRegion.toPolygonFeature());
+    }
+    fc.features = features;
+    fc.properties = new FeatureCollectionProperties();
+    
+    return fc;
+  }
+  
+  /**
+   * Container class for the {@code FeatureCollection} properties. 
+   */
+  private static class FeatureCollectionProperties {
+    String label;
+    
+    private FeatureCollectionProperties() {
+      this.label = "Basin Regions";
+    }
+  }
+ 
+}

--- a/src/gov/usgs/earthquake/nshmp/site/www/BasinTermService.java
+++ b/src/gov/usgs/earthquake/nshmp/site/www/BasinTermService.java
@@ -1,0 +1,305 @@
+package gov.usgs.earthquake.nshmp.site.www;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import gov.usgs.earthquake.nshmp.internal.GeoJson;
+import gov.usgs.earthquake.nshmp.internal.GeoJson.Feature;
+import gov.usgs.earthquake.nshmp.internal.GeoJson.FeatureCollection;
+import gov.usgs.earthquake.nshmp.site.www.ArcGis.ArcGisResult;
+import gov.usgs.earthquake.nshmp.site.www.Util.EnumParameter;
+import gov.usgs.earthquake.nshmp.site.www.Util.Key;
+import gov.usgs.earthquake.nshmp.site.www.Util.Status;
+
+import static gov.usgs.earthquake.nshmp.site.www.Util.GSON;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Web service for getting basin terms for {@code BasinModels} 
+ *    and {@code BasinRegions}.
+ * <br> 
+ * The basin terms are produced from the ArcGis Online web service, 
+ *    {@link ArcGis}.
+ * <br>
+ * Syntax: /nshmp-site/basin?latitude={latitude}&longitude={longitude}
+ *    &model={basinModel}
+ * <br>
+ * Example: /nshmp-site/basin?latitude=47&longitude=-122.5&model=Seattle 
+ *    
+ * @author Brandon Clayton
+ */
+@WebServlet(
+    name = "Basin Term Service",
+    description = "Utility for getting basin terms",
+    urlPatterns = {
+        "/basin",
+        "/basin/*"})
+public class BasinTermService extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+	
+	private static final String NAME = "Basin Term Service";
+	private static final String DESCRIPTION = "Get basin terms";
+	private static final String SYNTAX = "%s://%s/nshmp-site" +
+	      "?latitude={latitude}" +
+	      "&longitude={longitude}" + 
+	      "&model={basinModel}";
+	
+	/**
+	 * Handle the GET request and return JSON response. 
+	 * <br>
+	 * If the query string is empty then the JSON response is the {@link Metadata}.
+	 */
+	@Override
+	protected void doGet(
+	    HttpServletRequest request, 
+	    HttpServletResponse response) 
+	        throws ServletException, IOException {
+		
+	  PrintWriter writer = response.getWriter();
+	  
+	  String query = request.getQueryString();
+	  String pathInfo = request.getPathInfo();
+	  String host = request.getServerName();
+	  String requestUrl = request.getRequestURL()
+	      .append("?")
+	      .append(query)
+	      .toString();
+	  
+	  /*
+     * Checking custom header for a forwarded protocol so generated links can
+     * use the same protocol and not cause mixed content errors.
+     */
+    String protocol = request.getHeader("X-FORWARDED-PROTO");
+    if (protocol == null) {
+      /* Not a forwarded request. Honor reported protocol and port. */
+      protocol = request.getScheme();
+      host += ":" + request.getServerPort();
+    }
+    
+    requestUrl = requestUrl.replace("http://", protocol + "://");
+    
+    try {
+      if (isNullOrEmpty(query)) {
+        writer.printf(GSON.toJson(new Metadata()), protocol, host);
+        return;
+      }
+	  
+      RequestData requestData = buildRequest(request.getParameterMap());
+      Response svcResponse = processBasinTerm(requestData, requestUrl);
+      String json = GeoJson.cleanPoly(GSON.toJson(svcResponse));
+      writer.println(json);
+    } catch(Exception e) {
+      writer.println(Util.errorMessage(requestUrl, e));
+    }
+	}
+	
+	/**
+	 * Obtain the basin terms from {@link ArcGis#callService(double, double)} 
+	 *     and return {@code Response} with only the {@code BasinModels} of interest.
+	 *     
+	 * @param requestData - The {@code RequestData} 
+	 * @param requestUrl - The full request url
+	 * @return The {@code Response} to turn into JSON.
+	 * @throws IOException
+	 */
+	private Response processBasinTerm(RequestData requestData, String requestUrl) 
+	    throws IOException {
+	  ArcGisResult arcGisResult = ArcGis.callService(
+	      requestData.latitude, 
+	      requestData.longitude);
+	  
+	  Double z1p0Val = arcGisResult.basinModels.get(requestData.basinModel.z1p0);
+	  z1p0Val = requestData.basinRegion.equals(null) ? null : z1p0Val;
+	  Double z2p5Val = arcGisResult.basinModels.get(requestData.basinModel.z2p5);
+	  z2p5Val = requestData.basinRegion.equals(null) ? null : z2p5Val;
+	  
+	  BasinResponse z1p0 = new BasinResponse(requestData.basinModel.z1p0, z1p0Val);
+	  BasinResponse z2p5 = new BasinResponse(requestData.basinModel.z2p5, z2p5Val);
+	  
+	  ResponseData responseData = new ResponseData(z1p0, z2p5);
+	  Response response = new Response(requestData, responseData, requestUrl);
+	  
+	  return response;
+	}
+	
+	/**
+	 * Return {@code RequestData} by getting the parameters from the 
+	 *     {@code HttpServletRequest.getParameterMap()}.
+	 *     
+	 * @param paramMap The request parameter map.
+	 * @return A new instance of {@code RequestData}
+	 */
+	private static RequestData buildRequest(Map<String, String[]> paramMap) {
+	  double lat = Double.valueOf(Util.readValue(paramMap, Key.LATITUDE));
+	  double lon = Double.valueOf(Util.readValue(paramMap, Key.LONGITUDE));
+	  BasinRegion basinRegion = BasinRegion.findRegion(lat, lon);
+	  
+	  BasinModel basinModel = getBasinModel(basinRegion, paramMap); 
+	  
+	  return new RequestData(basinRegion, basinModel, lat, lon);
+	}
+
+	/**
+	 * Return 
+	 * @param basinRegion
+	 * @param paramMap
+	 * @return
+	 */
+	private static BasinModel getBasinModel(
+	    BasinRegion basinRegion, 
+	    Map<String, String[]> paramMap) {
+	  Boolean hasBasinModel = paramMap.containsKey(Key.MODEL.toString());
+	  
+	  return hasBasinModel ? 
+	      BasinModel.fromId(Util.readValue(paramMap, Key.MODEL)) :
+	      basinRegion.defaultModel;
+	}
+	
+	/**
+	 * Container class to hold the request parameters from the URL query, including:
+	 *     <ul>
+	 *       <li> latitude - {@code double} </li>
+	 *       <li> longitude - {@code double} </li>
+	 *       <li> basinModel - {@code BasinModels} </li>
+	 *       <li> BasinRegion - {@code BasinRegions} </li>
+	 *     </ul>
+	 */
+	private static class RequestData {
+	  final double latitude;
+	  final double longitude;
+	  final BasinModel basinModel;
+	  final BasinRegion basinRegion;
+	  
+	  RequestData(
+	      BasinRegion basinRegion, 
+	      BasinModel basinModel, 
+	      double latitude, 
+	      double longitude) {
+	    this.basinRegion = basinRegion;
+	    this.basinModel = basinModel;
+	    this.latitude = latitude;
+	    this.longitude = longitude;
+	  }
+	}
+	
+	/**
+	 * Container class to hold information for each basin term. 
+	 */
+	private static class BasinResponse {
+	  String model;
+	  Double value;
+	 
+	  BasinResponse(String model, Double value) {
+	    this.model = model;
+	    this.value = value;
+	  }
+	}
+	
+	/**
+	 * Container class to hold a {@code BasinResponse} for:
+	 *     <ul>
+	 *       <li> z1p0 </li>
+	 *       <li> z2p5 </li>
+	 *     </ul> 
+	 */
+	private static class ResponseData {
+	  BasinResponse z1p0;
+	  BasinResponse z2p5;
+	  
+	  ResponseData(BasinResponse z1p0, BasinResponse z2p5) {
+	    this.z1p0 = z1p0;
+	    this.z2p5 = z2p5;
+	  }
+	}
+	
+	/**
+	 * Container structure for the JSON response. Example:
+	 * <pre>
+	 * {
+	 *   status: "success",
+	 *   name: "Basin Term Service",
+	 *   date: ,
+	 *   url: "/nshmp-site/basin?",
+	 *   request: {
+	 *     latitude: ,
+	 *     longitude: ,
+	 *     basinModel: {},
+	 *     basinRegion: {},
+	 *   },
+	 *   response: {
+	 *     z1p0: {
+	 *       model: ,
+	 *       value: ,
+	 *     }, 
+	 *     z2p5: {
+	 *       model: ,
+	 *       value: ,
+	 *     },
+	 *   }
+	 * }
+	 * </pre>
+	 */
+	private static class Response {
+	  final String status;
+	  final String name;
+	  final String date;
+	  final String url;
+	  final RequestData request;
+	  final ResponseData response;
+	  
+	  Response(RequestData requestData, ResponseData responseData, String url) {
+	    this.status = Status.SUCCESS.toString();
+	    this.name = NAME;
+	    this.date = new Date().toString();
+	    this.url = url;
+	    this.request = requestData;
+	    this.response = responseData;
+	  }
+	}
+	
+	/**
+	 * Container to produce the {@code BasinTermService} usage that shows:
+	 *     <ul>
+	 *       <li> All basin models - {@code EnumSet.of(BasinModels)} </li>
+	 *       <li> All basin regions - {@code EnumSet.of(BasinRegions} </li>
+	 *       <li> GeoJson feature collection - {@link BasinRegion#toFeatureCollection()} </li>
+	 *     </ul> 
+	 */
+	private static class Metadata {
+	  final String status;
+	  final String name;
+	  final String description;
+	  final String syntax;
+	  final EnumParameter<BasinModel> basinModels; 
+	  final EnumParameter<BasinRegion> basinRegions; 
+	  final FeatureCollection<Feature> geoJson;
+	  
+	  Metadata() {
+	    this.status = Status.USAGE.toString();
+	    this.name = NAME;
+	    this.description = DESCRIPTION;
+	    this.syntax = SYNTAX;
+	    
+	    this.basinModels = new EnumParameter<>(
+	        "Basin models",
+	        EnumSet.allOf(BasinModel.class));
+	    
+	    this.basinRegions = new EnumParameter<>(
+	        "Basin regions",
+	        EnumSet.allOf(BasinRegion.class));
+	    
+	    this.geoJson = BasinRegion.toFeatureCollection();
+	  }
+	}
+
+}

--- a/src/gov/usgs/earthquake/nshmp/site/www/Util.java
+++ b/src/gov/usgs/earthquake/nshmp/site/www/Util.java
@@ -1,0 +1,238 @@
+package gov.usgs.earthquake.nshmp.site.www;
+
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import gov.usgs.earthquake.nshmp.site.www.ArcGis.ArcGisResult;
+
+/**
+ * Utilities class 
+ * 
+ * @author Brandon Clayton
+ */
+public class Util {
+  /**
+   * A {@code Gson} instance with serializers and deserializers:
+   *    <ul> 
+   *      <li> {@link BasinRegionSerializer} </li>
+   *      <li> {@link BasinModelSerializer} </li>
+   *      <li> {@link ArcGisDeserializer} </li>
+   *    </ul>
+   */ 
+  static final Gson GSON;
+  
+  static {
+    GSON = new GsonBuilder()
+        .registerTypeAdapter(BasinRegion.class, new BasinRegionSerializer())
+        .registerTypeAdapter(BasinModel.class, new BasinModelSerializer())
+        .registerTypeAdapter(ArcGisResult.class, new ArcGisDeserializer())
+        .disableHtmlEscaping()
+        .serializeNulls()
+        .setPrettyPrinting()
+        .create();
+  }
+
+  /**
+   * URL query key identifiers for {@link ArcGis} and {@link BasinTermService}.
+   */
+  enum Key {
+    /* ArcGIS Service Keys */
+    ATTRIBUTES,
+    VS30,
+    Z1P0,
+    Z2P5,
+    
+    /* Basin Term Service Keys */
+    LATITUDE,
+    LONGITUDE,
+    MODEL;
+    
+    /**
+     * Convert the {@code Enum} to a upper camel case {@code String}.
+     */
+    String toUpperCamel() {
+      return UPPER_UNDERSCORE.to(UPPER_CAMEL, name());
+    }
+   
+    /**
+     * Convert the {@code Enum} to a lower case {@code String}.
+     */
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+  
+  /**
+   * Service request identifiers
+   */
+  enum Status {
+    ERROR,
+    SUCCESS,
+    USAGE;
+    
+    /**
+     * Convert the {@code Enum} to a lower case {@code String}.
+     */
+    @Override 
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+ 
+  /**
+   * Return the {@code String} value of the matching {@value Key}
+   *    in a {@code HttpServletRequest.getParameterMap()}.
+   *    
+   * @param paramMap - The parameter map
+   * @param key - The {@code Enum}
+   * @return The value associated with the key.
+   */
+  static String readValue(Map<String, String[]> paramMap, Key key) {
+    String keyStr = key.toString();
+    String[] values = paramMap.get(keyStr);
+    checkNotNull(values, "Missing query key: %s", keyStr);
+    checkState(!isNullOrEmpty(values[0]), "Empty value array for key: %s", key);
+    
+    return values[0];
+  }
+ 
+  /**
+   * A {@code JsonSerializer} for {@code BasinRegions} 
+   */
+  private static final class BasinRegionSerializer 
+      implements JsonSerializer<BasinRegion> {
+
+    @Override
+    public JsonElement serialize(
+        BasinRegion basinRegion, 
+        Type typeOfSrc, 
+        JsonSerializationContext context) {
+  
+      JsonObject json = new JsonObject();
+  
+      json.addProperty("label", basinRegion.label);
+      json.addProperty("id", basinRegion.id);
+      json.addProperty("minlatitude", basinRegion.minlatitude);
+      json.addProperty("maxlatitude", basinRegion.maxlatitude);
+      json.addProperty("minlongitude", basinRegion.minlongitude);
+      json.addProperty("maxlongitude", basinRegion.maxlongitude);
+      json.addProperty("defaultModel", basinRegion.defaultModel.id);
+  
+      return json;
+    }
+  }
+
+  /**
+   * A {@code JsonSerializer} for {@code BasinModels} 
+   */
+  private static final class BasinModelSerializer 
+      implements JsonSerializer<BasinModel> {
+    
+    @Override
+    public JsonElement serialize(
+        BasinModel basinModel,
+        Type typeOfSrc,
+        JsonSerializationContext context) {
+  
+      JsonObject json = new JsonObject();
+  
+      json.addProperty("id", basinModel.id);
+      json.addProperty("z1p0", basinModel.z1p0);
+      json.addProperty("z2p5", basinModel.z2p5);
+  
+      return json;
+    }
+  }
+  
+  /**
+   * A {@code JsonDeserializer} for {@code ArcGisResult} 
+   */
+  static final class ArcGisDeserializer
+      implements JsonDeserializer<ArcGisResult> {
+
+    @Override
+    public ArcGisResult deserialize(JsonElement json, Type typeOfT,
+        JsonDeserializationContext context) throws JsonParseException {
+  
+      JsonObject jsonObject = json.getAsJsonObject();
+      JsonObject attributesJson = jsonObject.get(Key.ATTRIBUTES.toString())
+          .getAsJsonObject();
+      Map<String, Double> basinModels = new HashMap<>();
+  
+      for (String key : attributesJson.keySet()) {
+        if (key.contains(Key.Z1P0.toUpperCamel()) || 
+            key.contains(Key.Z2P5.toUpperCamel())) {
+          Double value = attributesJson.get(key).getAsDouble();
+          value = Double.isNaN(value) ? null : value;
+          basinModels.put(key, value);
+        }
+      }
+ 
+      double vs30 = attributesJson.get(Key.VS30.toUpperCamel()).getAsDouble();
+      ArcGisResult result = new ArcGisResult();
+      result.setBasinModels(basinModels);
+      result.setVs30(vs30);
+  
+      return result;
+    }
+  }
+ 
+  /**
+   * Method for obtaining error messages in JSON format. 
+   * @param url - The URL that threw an error
+   * @param e - The error
+   * @return JSON string
+   */
+  static String errorMessage(String url, Throwable e) {
+    Error error = new Error(url, e);
+    return GSON.toJson(error);
+  }
+  
+  /**
+   * Container for creating an error message. 
+   */
+  private static class Error {
+    final String status;
+    final String request;
+    final String message;
+    
+    private Error(String request, Throwable e) {
+      this.status = Status.ERROR.toString();
+      this.request = request;
+      this.message = e.getMessage();
+    }
+  }
+  
+  /**
+   * Container class for a {@code Enum}. 
+   */
+  static class EnumParameter<E extends Enum<E>>{
+    final String label;
+    final Set<E> values;
+    
+    EnumParameter(String label, Set<E> values) {
+      this.label = label;
+      this.values = values;
+    }
+  }
+  
+}


### PR DESCRIPTION
#### Basin Service
* Location: /nshmp-site/basin
* The basin service first calls the ArcGis Online web service at https://dev-earthquake.cr.usgs.gov/arcgis/rest/services/haz/basin/MapServer/identify

Basin terms are only supported using the following regions:
* Los Angeles: lat 32.94 to 35.16 N, long -119.8 to -116.7 W
* Bay Area: lat 36.42 to 39.02 N, long -123.62 to -120.6 W
* Wasatch: lat 39.0 to 42.52 N, long -113.26 to -110.74 W
* Seattle: lat 46.5 to 48.5 N, long -123.5 to -121.5 W

#### Basin Service Query Examples
* Query: /nshmp-site/basin?latitude={latitude}&longitude={longitude}&model={basinModel}
* Query: /nshmp-site/basin?latitude={latitude}&longitude={longitude}

When model is not supplied, the default basin model is used based on: 
* Los Angeles: cvms S4.26m01 (Lee et al., 2014)
* Bay Area: BayArea10 (Aagaard et al., 2010)
* Wasatch: Wasatch08 (Magistrale et al., 2008)
* Seattle: Seattle07 (Stephenson, 2007)
